### PR TITLE
fix: redirect to aws category

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -22,7 +22,7 @@ With this blog, my team of authors and I produce:
 * deep-dive tutorials about [Spring Boot](/categories/spring-boot)
 * hands-on tutorials about [Java](/categories/java)
 * hands-on tutorials about [Node.js](/categories/node)
-* hands-on tutorials about [AWS](/categories/node)
+* hands-on tutorials about [AWS](/categories/aws)
 * opinion pieces on practices of the [Software Craft](/categories/software-craft)
 * the occasional [book notes](/categories/book-notes) of a (non-fiction) book I've read.
 * ... and more.


### PR DESCRIPTION
I was [browsing through the site](https://reflectoring.io/about/). Oddly enough, the AWS category hyperlink was pointing to Node one. I've corrected the link to redirect to the right place.

Since this PR isn't related to an article, I don't believe it has to go through the traditional checklist.

